### PR TITLE
Stop damage to wolves in No pvp villages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>groupId</groupId>
+    <groupId>BetaMC</groupId>
     <artifactId>JVillage</artifactId>
-    <version>1.0.18</version>
+    <version>1.1.0</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVMobListener.java
+++ b/src/main/java/com/johnymuffin/jvillage/beta/listeners/JVMobListener.java
@@ -60,6 +60,15 @@ public class JVMobListener extends EntityListener implements Listener {
         }
         EntityDamageByEntityEvent event = (EntityDamageByEntityEvent) preEvent;
 
+        if (event.getEntity() instanceof Wolf) {
+            Wolf wolf = (Wolf) event.getEntity();
+            Village wolfVillage = plugin.getVillageAtLocation(wolf.getLocation());
+            if (wolfVillage != null && !wolfVillage.isPvpEnabled()) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+
         CraftEntity damager = (CraftEntity) event.getDamager();
 
         //Return if the victim is not a player


### PR DESCRIPTION
Stop damage to wolves in villages with _PvP-Enabled_ flag set to _false_.